### PR TITLE
パスワード再設定用のViewデザインを修正し、Feature Specを追加

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,21 @@
-<h2>Change your password</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+<div class="login__wrapper">
+  <div class="login__container">
+    <section class="form">
+      <h2>パスワード再設定</h2>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= f.hidden_field :reset_password_token %>
+        <fieldset>
+          <div class="form__item">
+            <p><%= f.label '新しいパスワード' %></p>
+            <p><%= f.password_field :password, placeholder: "新しいパスワード" %></p>
+          </div>
+          <div class="form__item">
+            <p><%= f.label '新しいパスワード（確認）' %></p>
+            <p><%= f.password_field :password_confirmation, placeholder: "確認のため、再度新しいパスワードを入力してください" %></p>
+          </div>
+          <%= f.submit "再設定" %>
+        </fieldset>
+      <% end %>
+    </section>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,21 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="login__wrapper">
+  <div class="login__container">
+    <section class="form">
+      <p>以下にご入力のアドレスに、パスワード再設定用のメールを送信いたします。ご確認の上、再設定をお願いいたします。</p>
+      <h2>パスワードをお忘れの方</h2>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+        <fieldset>
+          <div class="form__item">
+            <p><%= f.label 'メールアドレス' %></p>
+            <p><%= f.email_field :email, placeholder: "メールアドレス" %></p>
+          </div>
+          <%= f.submit "送信" %>
+        </fieldset>
+      <% end %>
+    </section>
+    <section class="login__link-area">
+      <p>ログインは<%= link_to 'こちら', login_path %></p>
+      <p>登録が済んでいない方は<%= link_to 'こちら', register_path %></p>
+    </section>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -19,6 +19,8 @@ ja:
               confirmation: "が内容とあっていません。"
             password_confirmation:
               confirmation: "がパスワードと一致しません。"
+            confirmation_token:
+              invalid: "は有効でありません。"
     attributes:
       user:
         current_password: "現在のパスワード"

--- a/spec/features/reset_user_password_spec.rb
+++ b/spec/features/reset_user_password_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature "EditUsers", type: :feature do
+  background do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def extract_confirmation_url(mail)
+    body = mail.body.encoded
+    body[/http[^"]+/]
+  end
+
+  let(:user) { create(:user) }
+  scenario "パスワード再設定ページでパスワードを変更し、変更後のパスワードでログインする" do
+    visit new_user_password_path
+    fill_in "メールアドレス", with: user.email
+    expect { click_button "送信" }.to change { ActionMailer::Base.deliveries.size }.by(1)
+    expect(page).to have_content "パスワードの再設定について数分以内にメールでご連絡いたします。"
+
+    # 送信されたメールのURLを取得してアクセスし、メールアドレスが確認できたことを確認
+    mail = ActionMailer::Base.deliveries.last
+    url = extract_confirmation_url(mail)
+    visit url
+
+    fill_in "新しいパスワード", with: "newtestuser"
+    fill_in "確認のため、再度新しいパスワードを入力してください", with: "newtestuser"
+    click_button "再設定"
+    expect(page).to have_content "パスワードが正しく変更されました。"
+    logout
+    login(user, "newtestuser")
+  end
+end


### PR DESCRIPTION
以下作業を実行。
・パスワード再設定用のメール送信ページのViewデザインを修正。
・パスワード再設定用メールに記載のURLから遷移した、パスワード再設定ページのViewデザインを修正。
・上記用のFeature Specを作成。