### PR TITLE
使用するDBをMySQLに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # ベースとなるDocker Imageをruby:2.7に指定
 FROM ruby:2.7.0
-# nodejs、postgresql-client、yarn、chromium-driverのインストール
-RUN apt-get update -qq && apt-get install -y nodejs postgresql-client yarn chromium-driver
-# Docker内にmyappディレクトリを作成し、Dockerfileでのコマンド実行時の基準にmyappを指定
-RUN mkdir /myapp
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -qq \
+    && apt-get install -y nodejs yarn \
+    && mkdir /myapp
 WORKDIR /myapp
 # Docker内のmyappディレクトリにホストのGemfile、Gemfile.lockをコピーし、Gemを読み込んでアプリ全体もコピー
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
-RUN gem install bundler
 RUN bundle install
 COPY . /myapp
 # 特定のserver.pidファイルが存在するときにサーバーが再起動しないようにする問題を修正

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,7 @@ ruby '2.7.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
-# Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
+gem 'mysql2'
 # Use Puma as the app server
 gem 'puma', '~> 4.3'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,11 +158,11 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.3.3)
+    mysql2 (0.5.3)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
-    pg (1.2.2)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
@@ -303,7 +303,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
-  pg (>= 0.18, < 2.0)
+  mysql2
   poltergeist
   puma (~> 4.3)
   rails (~> 6.0.2, >= 6.0.2.1)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,88 +1,21 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
 default: &default
-  adapter: postgresql
-  encoding: unicode
-  host: db
-  username: postgres
-  password: ENV['POSTGRES_PASSWORD']
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  adapter: mysql2
+  encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV.fetch("MYSQL_USERNAME", "root") %>
+  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
+  host: <%= ENV.fetch("MYSQL_HOST", "db") %>
 
 development:
   <<: *default
   database: myapp_development
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: pay_tsuka
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: myapp_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 production:
   <<: *default
-  database: pay_tsuka_production
-  username: pay_tsuka
-  password: <%= ENV['pay_tsuka_DATABASE_PASSWORD'] %>
+  database: myapp_production
+  username: myapp
+  password: <%= ENV['MYAPP_DATABASE_PASSWORD'] %>

--- a/db/migrate/20200528165644_devise_create_users.rb
+++ b/db/migrate/20200528165644_devise_create_users.rb
@@ -18,8 +18,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.integer  :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-      t.inet     :current_sign_in_ip
-      t.inet     :last_sign_in_ip
+      t.string     :current_sign_in_ip
+      t.string     :last_sign_in_ip
 
       ## Confirmable
       t.string   :confirmation_token

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,10 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2020_10_27_192028) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "contacts", force: :cascade do |t|
+  create_table "contacts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "tel", null: false
     t.string "email", null: false
@@ -24,13 +21,13 @@ ActiveRecord::Schema.define(version: 2020_10_27_192028) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "keep_shops", force: :cascade do |t|
+  create_table "keep_shops", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "shop_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "reviews", force: :cascade do |t|
+  create_table "reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "shop_id"
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
@@ -39,7 +36,7 @@ ActiveRecord::Schema.define(version: 2020_10_27_192028) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
-  create_table "user_keep_shops", force: :cascade do |t|
+  create_table "user_keep_shops", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "keep_shop_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -49,7 +46,7 @@ ActiveRecord::Schema.define(version: 2020_10_27_192028) do
     t.index ["user_id"], name: "index_user_keep_shops_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -58,8 +55,8 @@ ActiveRecord::Schema.define(version: 2020_10_27_192028) do
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,25 @@
 version: '3'
 services:
   db:
-    image: postgres
-     # dbにマウントする設定ファイルのパスを指定
-    volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+    image: mysql:8.0
     environment:
-      POSTGRES_PASSWORD: ENV['POSTGRES_PASSWORD']
+      MYSQL_ROOT_PASSWORD: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
+    ports:
+      - '3306:3306'
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-data:/var/lib/mysql
   web:
-    # ComposeFileを実行してビルドされるときのパスを指定
-    build:
-      context: .
-      dockerfile: Dockerfile
-    command: /bin/bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
-    # マウントする設定ファイルのパスを指定
+    build: .
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
     ports:
       - "3000:3000"
     depends_on:
-      # webというServiceの前に、db、chromeというServiceを実行する
       - db
-      - chrome
-    # 標準入出力をアタッチ
     stdin_open: true
     tty: true
-  chrome:
-    # システムスペックを実行できるようにSeleniumのイメージを取得
-    image: selenium/standalone-chrome:3.141.59-dubnium
-    ports:
-      - 4444:4444
+volumes:
+  mysql-data:
+    driver: local


### PR DESCRIPTION
DBをPostgreSQLからMySQLに変更するに伴い、以下を変更
・gemをpgからmysql2に変更
・Dockerfile／docker-compose.yml／database.ymlをMySQL仕様に変更
・PostgreSQL環境では、devies導入時に「current_sign_in_ip」「last_sign_in_ipinet」をinet型で作成されていたので、string型に変更