### PR TITLE
ec2デプライ用にDockerとデータベース関連ファイルを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # ベースとなるDocker Imageをruby:2.7に指定
 FROM ruby:2.7.0
 # nodejs、postgresql-client、yarn、chromium-driverのインストール
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y vim nodejs postgresql-client yarn chromium-driver
 # Docker内にmyappディレクトリを作成し、Dockerfileでのコマンド実行時の基準にmyappを指定
 RUN mkdir /myapp

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   encoding: unicode
   host: db
   username: postgres
-  password:
+  password: password
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,7 +65,7 @@ Rails.application.configure do
   # 会員登録時にメールを送る
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  host = "#{ENV['HEROKU_APPNAME']}.herokuapp.com"
+  host = "#{ENV['EC2_APPNAME']}.paytsuka.com"
   config.action_mailer.default_url_options = { host: host, protocol: 'https' }
   config.action_mailer.smtp_settings = {
     enable_starttls_auto: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: ENV['POSTGRES_PASSWORD']
+      POSTGRES_PASSWORD: password
   web:
     # ComposeFileを実行してビルドされるときのパスを指定
     build:
@@ -21,12 +21,3 @@ services:
     depends_on:
       # webというServiceの前に、db、chromeというServiceを実行する
       - db
-      - chrome
-    # 標準入出力をアタッチ
-    stdin_open: true
-    tty: true
-  chrome:
-    # システムスペックを実行できるようにSeleniumのイメージを取得
-    image: selenium/standalone-chrome:3.141.59-dubnium
-    ports:
-      - 4444:4444


### PR DESCRIPTION
EC2デプライのために、以下作業を実行。
・アプリ立ち上げ時にwebpackerエラーが出るため、Dockerfile内にてyarnの新しいバージョンをインストール
・DBパスワードを設定
・CircleCi導入用に準備しておいたDockerfileのサービス（chrome）を削除
・Heroku用に設定していた環境変数名を修正