### PR TITLE
Docker環境を本番用と開発用に分けて用意

### DIFF
--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -4,10 +4,10 @@ FROM ruby:2.7.0
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y vim nodejs postgresql-client yarn chromium-driver
-# Docker内にmyappディレクトリを作成し、Dockerfileでのコマンド実行時の基準にmyappを指定
+# Docker内にappディレクトリを作成し、Dockerfileでのコマンド実行時の基準にmyappを指定
 RUN mkdir /app
 WORKDIR /app
-# Docker内のmyappディレクトリにホストのGemfile、Gemfile.lockをコピーし、Gemを読み込んでアプリ全体もコピー
+# Docker内のappディレクトリにホストのGemfile、Gemfile.lockをコピーし、Gemを読み込んでアプリ全体もコピー
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
 RUN gem install bundler
@@ -17,5 +17,7 @@ COPY . /app
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
-# puma.sockを配置するディレクトリを作成
-RUN mkdir -p tmp/sockets
+# コンテナ起動時に使用するポートを定義
+EXPOSE 3000
+# Docker起動時にデフォルトで実行されるコマンドを定義
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile_prd
+++ b/Dockerfile_prd
@@ -1,0 +1,17 @@
+# ベースとなるDocker Imageをruby:2.7に指定
+FROM ruby:2.7.0
+# nodejs、postgresql-client、yarn、chromium-driverのインストール
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get install -y vim nodejs postgresql-client yarn chromium-driver
+# Docker内にmyappディレクトリを作成し、Dockerfileでのコマンド実行時の基準にmyappを指定
+RUN mkdir /app
+WORKDIR /app
+# Docker内のmyappディレクトリにホストのGemfile、Gemfile.lockをコピーし、Gemを読み込んでアプリ全体もコピー
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+RUN gem install bundler
+RUN bundle install
+COPY . /app
+# puma.sockを配置するディレクトリを作成
+RUN mkdir -p tmp/sockets

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,6 +28,10 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # 独自ドメインからのアクセスを許可する
+  config.hosts << "www.pay-tsuka.tk"
+  config.hosts << "pay-tsuka-alb-1005445246.us-east-2.elb.amazonaws.com"
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-amazon:
-  service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: ap-northeast-1 #東京
-  bucket: pay-tsuka
+# amazon:
+# service: S3
+# access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+# secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+# region: ap-northeast-1 #東京
+# bucket: pay-tsuka
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  dev:
+    # ComposeFileを実行してビルドされるときのパスを指定
+    build:
+      context: .
+      dockerfile: Dockerfile_dev
+    command: /bin/bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    # マウントする設定ファイルのパスを指定
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      # webというServiceの前に、db、chromeというServiceを実行する
+      - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - ./tmp/db:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
-  web:
+  app:
     # ComposeFileを実行してビルドされるときのパスを指定
     build:
       context: .
+      dockerfile: Dockerfile_prd
     command: /bin/bash -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb"
     # マウントする設定ファイルのパスを指定
     volumes:
@@ -21,7 +22,11 @@ services:
     depends_on:
       # webというServiceの前に、db、chromeというServiceを実行する
       - db
-  nginx:
+    stdin_open: true
+    tty: true
+    environment:
+      RAILS_ENV: production
+  web:
     build:
       context: containers/nginx
     volumes:
@@ -30,7 +35,7 @@ services:
     ports:
       - 80:80
     depends_on:
-      - web
+      - app
 volumes:
   public-data:
   tmp-data:


### PR DESCRIPTION
開発効率化のために、Docker環境を本番用と開発用でそれぞれ用意。
【本番】Dockerfile_prd、docker-compose.yml
・アプリ内に画像アップロード機能がないため、S3関連の記述をコメントアウト

【開発】Dockerfile_dev、docker-compose.yml + docker-compose.dev.yml
・config/environments/development.rbのアクセス許可hostsにEC2とドメインを追加