### PR TITLE
Gemfileを整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,9 +73,6 @@ yarn-debug.log*
 # dotenv environment variables file
 .env
 
-# er diagram pdf file
-erd.pdf
-
 # End of https://www.gitignore.io/api/rails
 
 /public/packs

--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,6 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
-# 環境変数定義用
-gem 'dotenv-rails'
-
 # ページネーション
 gem 'kaminari'
 
@@ -35,9 +32,6 @@ gem "devise"
 # deviseの日本語化
 gem 'devise-i18n'
 gem 'devise-i18n-views'
-
-# アプリ名変更
-gem 'rename'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
@@ -50,7 +44,6 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.6.0'
   gem "factory_bot_rails"
-  gem 'rails-erd'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    choice (0.2.0)
     cliver (0.3.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
@@ -103,10 +102,6 @@ GEM
       devise (>= 4.7.1)
     devise-i18n-views (0.3.7)
     diff-lcs (1.4.2)
-    dotenv (2.7.5)
-    dotenv-rails (2.7.5)
-      dotenv (= 2.7.5)
-      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     factory_bot (6.0.2)
       activesupport (>= 5.0.0)
@@ -193,11 +188,6 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (6.0.3.2)
@@ -211,14 +201,9 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.1)
-    rename (1.0.6)
-      activesupport
-      rails (>= 3.0.0)
-      thor (>= 0.19.1)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.4)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -236,8 +221,6 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby_dep (1.5.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -297,7 +280,6 @@ DEPENDENCIES
   devise
   devise-i18n
   devise-i18n-views
-  dotenv-rails
   factory_bot_rails
   jbuilder (~> 2.7)
   kaminari
@@ -307,8 +289,6 @@ DEPENDENCIES
   poltergeist
   puma (~> 4.3)
   rails (~> 6.0.2, >= 6.0.2.1)
-  rails-erd
-  rename
   rspec-rails (~> 3.6.0)
   sass-rails (>= 6)
   spring


### PR DESCRIPTION
以下の通り、Gemfileを整理した。
・環境変数をcredentialsに設定したためdotenvを削除
・アプリ名のリネームに用いたrenameはすでに不要であるため削除
・DB構造がシンプルでER図は不要であると判断したためrails-erdを削除