### PR TITLE
URIのエンコード時に、addressableをrequireさせる

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?


### PR DESCRIPTION
Production環境でAddressableが使用できなかったため、URIのエンコード時にaddressableをrequireさせる